### PR TITLE
Update package.json remove fs as default package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 		"express": "^4.16.3",
 		"express-session": "^1.15.6",
 		"file-type": "^9.0.0",
-		"fs": "0.0.1-security",
 		"history": "^4.7.2",
 		"mocha": "^5.2.0",
 		"morgan": "^1.9.0",


### PR DESCRIPTION
fs is node.js filesystem module.  You don't need to build it to package.json
If you read the description in https://www.npmjs.com/package/fs it tells you 'This package name is not currently in use'.